### PR TITLE
Optimize deletion

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,22 +41,6 @@ func (n *Node[K, V]) isLeaf() bool {
 	return len(n.children) == 0
 }
 
-func (n *Node[K, V]) getSuccesor(i int) Item[K, V] {
-	current := n.children[i+1]
-	for !current.isLeaf() {
-		current = current.children[0]
-	}
-	return current.items[0]
-}
-
-func (n *Node[K, V]) getPredecessor(i int) Item[K, V] {
-	current := n.children[i]
-	for !current.isLeaf() {
-		current = current.children[len(current.children)-1]
-	}
-	return current.items[len(current.items)-1]
-}
-
 func NewBtree[K cmp.Ordered, V any](degree int) *BTree[K, V] {
 	if degree < 2 {
 		panic("Invalid degree. Must be larger than 1")


### PR DESCRIPTION
Optimized deletions by getting and deleting predecessor or succesor in one traversel, not two

```
goos: linux
goarch: amd64
pkg: github.com/push-and-pray/btree
cpu: 12th Gen Intel(R) Core(TM) i5-12400F
                                            │   old.txt    │              new.txt               │
                                            │    sec/op    │   sec/op     vs base               │
BTreeDelete/Delete_Degree_2_Size_+1000-12     1028.5n ± 1%   988.3n ± 2%  -3.91% (p=0.002 n=10)
BTreeDelete/Delete_Degree_2_Size_+10000-12    10.209µ ± 1%   9.795µ ± 1%  -4.06% (p=0.000 n=10)
BTreeDelete/Delete_Degree_2_Size_+100000-12    105.0µ ± 2%   101.1µ ± 1%  -3.76% (p=0.000 n=10)
BTreeDelete/Delete_Degree_4_Size_+1000-12     1036.5n ± 2%   981.6n ± 1%  -5.29% (p=0.000 n=10)
BTreeDelete/Delete_Degree_4_Size_+10000-12    10.157µ ± 2%   9.853µ ± 1%  -2.99% (p=0.000 n=10)
BTreeDelete/Delete_Degree_4_Size_+100000-12   103.95µ ± 1%   99.40µ ± 1%  -4.38% (p=0.000 n=10)
BTreeDelete/Delete_Degree_8_Size_+1000-12     1025.0n ± 2%   984.2n ± 1%  -3.98% (p=0.000 n=10)
BTreeDelete/Delete_Degree_8_Size_+10000-12    10.190µ ± 2%   9.782µ ± 1%  -4.00% (p=0.000 n=10)
BTreeDelete/Delete_Degree_8_Size_+100000-12   103.21µ ± 1%   99.50µ ± 1%  -3.59% (p=0.000 n=10)
geomean                                        10.30µ        9.885µ       -4.00%

                                            │   old.txt    │               new.txt               │
                                            │     B/op     │    B/op     vs base                 │
BTreeDelete/Delete_Degree_2_Size_+1000-12     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
BTreeDelete/Delete_Degree_2_Size_+10000-12    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
BTreeDelete/Delete_Degree_2_Size_+100000-12   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
BTreeDelete/Delete_Degree_4_Size_+1000-12     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
BTreeDelete/Delete_Degree_4_Size_+10000-12    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
BTreeDelete/Delete_Degree_4_Size_+100000-12   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
BTreeDelete/Delete_Degree_8_Size_+1000-12     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
BTreeDelete/Delete_Degree_8_Size_+10000-12    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
BTreeDelete/Delete_Degree_8_Size_+100000-12   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                  ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                            │   old.txt    │               new.txt               │
                                            │  allocs/op   │ allocs/op   vs base                 │
BTreeDelete/Delete_Degree_2_Size_+1000-12     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
BTreeDelete/Delete_Degree_2_Size_+10000-12    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
BTreeDelete/Delete_Degree_2_Size_+100000-12   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
BTreeDelete/Delete_Degree_4_Size_+1000-12     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
BTreeDelete/Delete_Degree_4_Size_+10000-12    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
BTreeDelete/Delete_Degree_4_Size_+100000-12   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
BTreeDelete/Delete_Degree_8_Size_+1000-12     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
BTreeDelete/Delete_Degree_8_Size_+10000-12    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
BTreeDelete/Delete_Degree_8_Size_+100000-12   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                  ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```